### PR TITLE
Added Recommendations to Favourites page

### DIFF
--- a/src/components/Favourites.jsx
+++ b/src/components/Favourites.jsx
@@ -1,9 +1,11 @@
 import { useContext } from "react";
 import { FavouritesDataContext } from "../contexts/FavouritesDataProvider";
 import AnimeList from "./AnimeCards";
+import { RecommendationsContext } from "../contexts/RecommendationsProvider";
 
 export default function Favourites() {
   const { favouritesData } = useContext(FavouritesDataContext);
+  const { recommendations } = useContext(RecommendationsContext);
 
   return (
     <div className="FavouritesContainer">
@@ -11,6 +13,12 @@ export default function Favourites() {
       <div className="FavouritesResults">
         {favouritesData.length > 0 && (
           /*console.log(favouritesData)*/ <AnimeList data={favouritesData} />
+        )}
+      </div>
+      <h1>Recommendations</h1>
+      <div className="RecommendationsResults">
+        {recommendations.length > 0 && (
+          /*console.log(favouritesData)*/ <AnimeList data={recommendations} />
         )}
       </div>
     </div>

--- a/src/contexts/RecommendationsProvider.jsx
+++ b/src/contexts/RecommendationsProvider.jsx
@@ -1,0 +1,80 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import { ApiContext } from "./ApiProvider";
+import { AnimeFavouritesContext } from "./AnimeFavouritesProvider";
+
+export const RecommendationsContext = createContext([]);
+
+export function RecommendationsProvider(props) {
+  // allows up to n recommendations per favourite, change this to increase
+  // number of reccomendations per favourite.
+  const MAX_RECOMMENDATIONS_PER_FAVOURITE = 5;
+
+  const { url } = useContext(ApiContext);
+  let { favourites } = useContext(AnimeFavouritesContext);
+  let [recommendations, setRecommendations] = useState([]);
+  //let [recommendationsData, setRecommendationsData] = useState([]);
+
+  let apiEndpoint = "anime/";
+  let apiEndpointSuffix = "/recommendations";
+
+  // keep unique recommendations only
+  function keepUniqueElements(array) {
+    return [...new Map(array.map((x) => [x.mal_id, x])).values()];
+  }
+
+  // Fisher-Yates algorithm to shuffle array:
+  const shuffleArray = (array) => {
+    for (let i = array.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      const temp = array[i];
+      array[i] = array[j];
+      array[j] = temp;
+    }
+  };
+
+  const retrieveRecommendations = async () => {
+    let newRecommendations = [];
+    try {
+      for (let i = favourites.length - 1; i >= 0; i--) {
+        try {
+          const response = await fetch(
+            url + apiEndpoint + favourites[i] + apiEndpointSuffix
+          );
+          if (!response.ok) {
+            throw new Error("Network response was not ok");
+          }
+
+          const data = await response.json();
+          if (data.data.length > MAX_RECOMMENDATIONS_PER_FAVOURITE) {
+            data.data.length = MAX_RECOMMENDATIONS_PER_FAVOURITE;
+          }
+          let favouriteRecommendations = data.data.map((e) => e.entry);
+          newRecommendations.push(...favouriteRecommendations);
+        } catch (error) {
+          console.error("Error fetching favourite data: ", error);
+        }
+      }
+      newRecommendations = keepUniqueElements(newRecommendations);
+      shuffleArray(newRecommendations);
+      setRecommendations(newRecommendations);
+    } catch (error) {}
+  };
+
+  // if favourites is updated, retrieve recommendation from API
+  useEffect(() => {
+    if (favourites.length > 0) {
+      retrieveRecommendations();
+    } else {
+      setRecommendations([]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [favourites]);
+
+  return (
+    <RecommendationsContext.Provider
+      value={{ recommendations, setRecommendations }}
+    >
+      {props.children}
+    </RecommendationsContext.Provider>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { AnimeFavouritesProvider } from "./contexts/AnimeFavouritesProvider";
 import { SearchResultsProvider } from './contexts/SearchResultsProvider';
 import { FavouritesDataProvider } from "./contexts/FavouritesDataProvider";
+import { RecommendationsProvider } from "./contexts/RecommendationsProvider";
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
@@ -17,7 +18,9 @@ root.render(
         <AnimeFavouritesProvider>
           <SearchResultsProvider>
             <FavouritesDataProvider>
-              <App />
+              <RecommendationsProvider>
+                <App />
+              </RecommendationsProvider>
             </FavouritesDataProvider>
           </SearchResultsProvider>
         </AnimeFavouritesProvider>


### PR DESCRIPTION
Recommendations showing on Favourites page 

(currently max. 5 per favourite, minus any duplicates. can change this by modifying 
const MAX_RECOMMENDATIONS_PER_FAVOURITE in RecommendationProvider.jsx.)

Gets 5 recommendations for each of your favourites, shuffles these together and removes any duplicates, displays on favourites page.
