### PR TITLE
removed empty genres title from recommendations

### DIFF
--- a/src/components/AnimeCards.jsx
+++ b/src/components/AnimeCards.jsx
@@ -31,19 +31,17 @@ export default function AnimeList(props) {
               onClick={() => handleCardClick(title)}
             />
             <p>
-              Genres:{" "}
-              {genres && 
-              genres.length > 0 && 
-              genres.map((genre) => (
-                <span key={genre.mal_id}>
-                  {genre.name}
-                  {genres.indexOf(genre) < genres.length - 1 ? ", " : ""}
-                </span>
-              ))}
+              {genres && genres.length > 0 && <span>Genres:</span>}{" "}
+              {genres &&
+                genres.length > 0 &&
+                genres.map((genre) => (
+                  <span key={genre.mal_id}>
+                    {genre.name}
+                    {genres.indexOf(genre) < genres.length - 1 ? ", " : ""}
+                  </span>
+                ))}
             </p>
-            <p className="TruncatedSynopsis">
-              {synopsis}
-            </p>
+            <p className="TruncatedSynopsis">{synopsis}</p>
             <FavouriteButton id={mal_id} />
           </div>
         );


### PR DESCRIPTION
"Genres:" now only displays when some genre content has loaded, so the empty genres section in recommendations no longer showing.